### PR TITLE
v1.02

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,16 @@
 # Change log
+**1.02**
+- Added new Perk Deck filter display method to sort text by character
+- Added a preview only scrollbar
+- Changed the skill count to always display as two digits / by Nexqua
+- Changed Profile Name highlight color to main color
+- Change the highlight color of the filter selector panel
+- Fixed the issue of default Profile Name index numbers
+- Fixed the issue of duplicate perk icons for "Crew Chief" and "Muscle" in the Profile List
+- Fixed some input issues in custom filter when selecting to add a profile
+- Fixed the issue in custom filter of resetting the position of the left list when switching
+- Some optimizations, Removed some useless variable
+
 **1.013**
 - Changed the font size of the Profile name 12 >> 14
 - Changed the font size of the Profile Skill Tree display 12 >> 13

--- a/loc/english.json
+++ b/loc/english.json
@@ -9,5 +9,6 @@
 	"menu_bp_dialog_please_create_a_filter" : "Please create a filter>_<",
 	
 	"menu_bp_perk_display_icon_1" : "Icon",
-	"menu_bp_perk_display_text" : "Text"
+	"menu_bp_perk_display_text" : "Text",
+	"menu_bp_perk_display_text_sort" : "Sorted Text"
 }

--- a/loc/schinese.json
+++ b/loc/schinese.json
@@ -6,8 +6,9 @@
 	"menu_bp_center_text" : "创建新的筛选器",
 	"menu_bp_enter_custom_name" : "输入名称",
 	"menu_bp_dialog_remove_filter" : "删除筛选器",
-	"menu_bp_dialog_please_create_a_filter" : "请创建筛选器>_<"
+	"menu_bp_dialog_please_create_a_filter" : "请创建筛选器>_<",
 	
 	"menu_bp_perk_display_icon_1" : "图标",
-	"menu_bp_perk_display_text" : "文字"
+	"menu_bp_perk_display_text" : "文字",
+	"menu_bp_perk_display_text_sort" : "文字排序"
 }

--- a/lua/multiprofilemanager.lua
+++ b/lua/multiprofilemanager.lua
@@ -1,7 +1,11 @@
+Hooks:PostHook(MultiProfileManager, "init", "ProfileRebornSetup", function(self)
+	self.profile_reborn = ProfileReborn:new()
+end)
+
 Hooks:OverrideFunction(MultiProfileManager, "open_quick_select", function(self)
-	if ProfileReborn then
+	if self.profile_reborn then
 		self:save_current()
 		-- self:load_current()
-		ProfileReborn:active()
+		self.profile_reborn:active()
 	end
 end)

--- a/mod.txt
+++ b/mod.txt
@@ -2,7 +2,7 @@
 	"name" : "Profile Reborn",
 	"description" : "",
 	"author" : "MetroLine",   
-	"version" : "1.013",
+	"version" : "1.02",
 	"blt_version": 2,
 	"hooks" : [
 		{


### PR DESCRIPTION
**1.02**
- Added new Perk Deck filter display method to sort text by character
- Added a preview only scrollbar
- Changed the skill count to always display as two digits / by Nexqua
- Changed Profile Name highlight color to main color
- Change the highlight color of the filter selector panel
- Fixed the issue of default Profile Name index numbers
- Fixed the issue of duplicate perk icons for "Crew Chief" and "Muscle" in the Profile List
- Fixed some input issues in custom filter when selecting to add a profile
- Fixed the issue in custom filter of resetting the pos