### PR TITLE
1.021

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 - The option to change the display mode of the Perk Deck filter is located to the right of the filter selector
 - Fixed crash related to mask
 
-
 **1.02**
 - Added new Perk Deck filter display method to sort text by character
 - Added a preview only scrollbar

--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
 # Change log
+**1.021**
+- The option to change the display mode of the Perk Deck filter is located to the right of the filter selector
+- Fixed crash related to mask
+
+
 **1.02**
 - Added new Perk Deck filter display method to sort text by character
 - Added a preview only scrollbar

--- a/lua/ProfileReborn.lua
+++ b/lua/ProfileReborn.lua
@@ -454,7 +454,13 @@ function ProfileReborn:set_profile(ui_panel, idx, profile, profile_idx)
 	end
 		
 	local slot = profile.mask
-	local mask_texture = managers.blackmarket:get_mask_icon(Global.blackmarket_manager.crafted_items["masks"][slot].mask_id)
+	local bm_mask = Global.blackmarket_manager.crafted_items["masks"][slot]
+
+	if not bm_mask then
+		return
+	end
+
+	local mask_texture = managers.blackmarket:get_mask_icon(bm_mask.mask_id)
 	local mask = panel:bitmap({
 		texture = mask_texture,
 		w = 70,
@@ -1301,7 +1307,7 @@ function ProfileReborn:set_perk_desk_profile()
 		h = 30
 	})
 	
-	self.perk_display_mode_panel:set_right(self._filter:left())
+	self.perk_display_mode_panel:set_left(self._filter:right())
 	self.perk_display_mode_panel:set_top(self._panel:bottom() + 2)
 	
 	local menu_arrows_texture = "guis/textures/menu_arrows"

--- a/mod.txt
+++ b/mod.txt
@@ -2,7 +2,7 @@
 	"name" : "Profile Reborn",
 	"description" : "",
 	"author" : "MetroLine",   
-	"version" : "1.02",
+	"version" : "1.021",
 	"blt_version": 2,
 	"hooks" : [
 		{


### PR DESCRIPTION
**1.021**
- The option to change the display mode of the Perk Deck filter is located to the right of the filter selector
- Fixed crash related to mask